### PR TITLE
use config with endpoints

### DIFF
--- a/rust/src/bin/consumer.rs
+++ b/rust/src/bin/consumer.rs
@@ -2,6 +2,7 @@ use clap::Parser;
 use eyre::eyre;
 use futures::StreamExt;
 use s2::{
+    client::S2Endpoints,
     types::{ReadOutput, ReadSessionRequest},
     Client, ClientConfig, StreamClient,
 };
@@ -91,7 +92,8 @@ async fn consume_records(
 }
 
 async fn run_consumer(auth_token: String, basin: String, stream: String) -> eyre::Result<()> {
-    let config = ClientConfig::new(auth_token);
+    let endpoints = S2Endpoints::from_env().map_err(|e| eyre!(e))?;
+    let config = ClientConfig::new(auth_token).with_endpoints(endpoints);
     let client = Client::new(config)
         .basin_client(basin.clone().try_into()?)
         .stream_client(stream.clone());

--- a/rust/src/bin/producer.rs
+++ b/rust/src/bin/producer.rs
@@ -2,6 +2,7 @@ use clap::Parser;
 use eyre::eyre;
 use rand::rngs::StdRng;
 use rand::{Rng, RngCore, SeedableRng};
+use s2::client::S2Endpoints;
 use s2::types::{AppendInput, MeteredBytes};
 use s2::{
     types::{AppendRecord, AppendRecordBatch, Header},
@@ -146,7 +147,8 @@ async fn run_producer(
     batch_size: Range<u64>,
     record_body_size: Range<u64>,
 ) -> eyre::Result<()> {
-    let config = ClientConfig::new(auth_token);
+    let endpoints = S2Endpoints::from_env().map_err(|e| eyre!(e))?;
+    let config = ClientConfig::new(auth_token).with_endpoints(endpoints);
     let client = Client::new(config)
         .basin_client(basin.clone().try_into()?)
         .stream_client(stream.clone());


### PR DESCRIPTION

<!-- ELLIPSIS_HIDDEN -->



> [!IMPORTANT]
> Use `S2Endpoints` in `consumer.rs` and `producer.rs` to configure endpoints from environment variables.
> 
>   - **Behavior**:
>     - Use `S2Endpoints::from_env()` in `run_consumer()` in `consumer.rs` and `run_producer()` in `producer.rs` to configure endpoints from environment variables.
>     - Modify `ClientConfig::new()` to include `.with_endpoints(endpoints)` in both `consumer.rs` and `producer.rs`.
>   - **Imports**:
>     - Add `use s2::client::S2Endpoints;` in both `consumer.rs` and `producer.rs`.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=s2-streamstore%2Fstress-stream&utm_source=github&utm_medium=referral)<sup> for 048a9b7add408413cadac01061dcde393c0374d1. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->